### PR TITLE
Automatically assign reviewer for repo management & CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This file lists mandatory reviewers for parts of the repository
+
+# Repository management, documentation, legal & CI
+/.github/* @jotoho
+/.clang-format @jotoho
+/LICENSE* @jotoho
+*.md @jotoho
+
+# Scripts of all kinds
+*.sh @jotoho
+*.bash @jotoho


### PR DESCRIPTION
Matters of repository maintainership and automation are managed by me.
All PRs that target those concerns should be passed by me first.

Additionally, any kind of script needs to be given a safety review.

Requesting review by @TimBeckmann
