### PR TITLE
Add project URL to code files

### DIFF
--- a/1/main.cpp
+++ b/1/main.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Repository: https://github.com/jotoho/cpp2-praktikum
 #include <iostream>
 #include "./stack.hpp"
 

--- a/1/stack.cpp
+++ b/1/stack.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Repository: https://github.com/jotoho/cpp2-praktikum
 #include "./stack.hpp"
 #include <stdexcept>
 

--- a/1/stack.hpp
+++ b/1/stack.hpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Repository: https://github.com/jotoho/cpp2-praktikum
 #include <cstddef>
 
 class Stack {

--- a/2/main.cpp
+++ b/2/main.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Repository: https://github.com/jotoho/cpp2-praktikum
 #include <iostream>
 #include "./stack.hpp"
 

--- a/2/stack.cpp
+++ b/2/stack.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Repository: https://github.com/jotoho/cpp2-praktikum
 #include "./stack.hpp"
 #include <stdexcept>
 

--- a/2/stack.hpp
+++ b/2/stack.hpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Repository: https://github.com/jotoho/cpp2-praktikum
 #include <cstddef>
 
 class Stack {


### PR DESCRIPTION
This should make it more obvious to teaching staff, that we're working on the same code
and point them to the right place in case they want more information or see the latest revisions.
(As well as perhaps discussion amongst us)

Closes https://github.com/jotoho/cpp2-praktikum/issues/5

Since this directly impacts our codebase, I'll wait for review(s)
