### PR TITLE
Exclude /.vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 a.out
 *.exe
 *.o
+
+/.vscode


### PR DESCRIPTION
This directory is automatically generated by vscode or it's extensions
and are typically of low to no value to a project.
(Especially since extensions usually don't ask for permission)
