### PR TITLE
CI: Change settings of automatic thread locker

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: dessant/lock-threads@v3.0.0
         with:
           github-token: ${{ github.token }}
-          issue-inactive-days: '60'
+          issue-inactive-days: '30'
           exclude-issue-created-before: ''
           exclude-issue-created-after: ''
           exclude-issue-created-between: ''
@@ -34,7 +34,7 @@ jobs:
           remove-issue-labels: ''
           issue-comment: ''
           issue-lock-reason: 'resolved'
-          pr-inactive-days: '60'
+          pr-inactive-days: '30'
           exclude-pr-created-before: ''
           exclude-pr-created-after: ''
           exclude-pr-created-between: ''

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,8 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    # Once a week at monday midnight
-    - cron: '0 0 * * 1'
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
I believe that these new settings are more reasonable for such a small repository like this

- chore(ci): reduce frequency of thread locking from weekly to monthly
- chore(ci): lock threads after 30 days, instead of 60

Requesting @TimBeckmann for quick review/acknowledgement
